### PR TITLE
fix(attachments): change attachment export name 

### DIFF
--- a/jihub.Base/JihubOptions.cs
+++ b/jihub.Base/JihubOptions.cs
@@ -67,6 +67,9 @@ namespace jihub.Base
         [Option(shortName: 'p', longName: "import-path", Required = false, HelpText = "The path of the directory the attachments should be imported to.")]
         public string? ImportPath { get; set; } = null;
 
+        [Option(shortName: 'b', longName: "branch", Required = false, HelpText = "The branch of the repository the attachments should be imported to.")]
+        public string? Branch { get; set; }
+
         /// <summary>
         /// Checks the options if everything is correct
         /// </summary>

--- a/jihub.Github/Models/GithubInformation.cs
+++ b/jihub.Github/Models/GithubInformation.cs
@@ -32,7 +32,8 @@ public record GitHubIssue
 public record GitHubLabel
 (
     string Name,
-    string Description
+    string Description,
+    string Color
 );
 
 public record GitHubMilestone(

--- a/jihub.Github/Models/UploadFileContent.cs
+++ b/jihub.Github/Models/UploadFileContent.cs
@@ -9,7 +9,8 @@ public record UploadFileContent(
     string Message,
     // Committer Committer,
     // string Sha,
-    string Content
+    string Content,
+    string Branch
 );
 
 /// <summary>

--- a/jihub.Github/Services/GithubService.cs
+++ b/jihub.Github/Services/GithubService.cs
@@ -195,13 +195,14 @@ public class GithubService : IGithubService
         }
     }
 
-    public async Task<GithubAsset> CreateAttachmentAsync(string owner, string repo, string importPath, (string Hash, string FileContent) fileData, string name, CancellationToken cts)
+    public async Task<GithubAsset> CreateAttachmentAsync(string owner, string repo, string? importPath, string? branch, (string Hash, string FileContent) fileData, string name, CancellationToken cts)
     {
         var directory = importPath == null ? string.Empty : $"{importPath}/";
         var url = $"repos/{owner}/{repo}/contents/{directory}{name}";
         var content = new UploadFileContent(
             $"Upload file {name}",
-            HttpUtility.HtmlEncode(fileData.FileContent)
+            HttpUtility.HtmlEncode(fileData.FileContent),
+            branch ?? "main"
         );
         var response = await _httpClient.PutAsJsonAsync(url, content, cts).ConfigureAwait(false);
 

--- a/jihub.Github/Services/IGithubService.cs
+++ b/jihub.Github/Services/IGithubService.cs
@@ -9,6 +9,6 @@ public interface IGithubService
     Task<GitHubMilestone> CreateMilestoneAsync(string name, string owner, string repo, CancellationToken cts);
     Task CreateIssuesAsync(string owner, string repo, IEnumerable<CreateGitHubIssue> issues, CancellationToken cts);
     Task<Committer> GetCommitter();
-    Task<GithubAsset> CreateAttachmentAsync(string owner, string repo, string importPath, (string Hash, string FileContent) fileData, string name, CancellationToken cts);
+    Task<GithubAsset> CreateAttachmentAsync(string owner, string repo, string? importPath, string? branch, (string Hash, string FileContent) fileData, string name, CancellationToken cts);
     Task<IEnumerable<GithubContent>> GetRepoContent(string owner, string repo, string path, CancellationToken cts);
 }

--- a/jihub.Parsers/Jira/JiraParser.cs
+++ b/jihub.Parsers/Jira/JiraParser.cs
@@ -81,8 +81,7 @@ public class JiraParser : IJiraParser
             try
             {
                 var asset = await _githubService
-                    .CreateAttachmentAsync(options.ImportOwner!, options.UploadRepo!, options.ImportPath, fileData, $"{jiraIssue.Key}-{attachment.Filename}",
-                        cts)
+                    .CreateAttachmentAsync(options.ImportOwner!, options.UploadRepo!, options.ImportPath, options.Branch, fileData, $"{jiraIssue.Key}-{attachment.Filename}", cts)
                     .ConfigureAwait(false);
                 assets.Add(asset);
             }

--- a/jihub.Parsers/Jira/JiraParser.cs
+++ b/jihub.Parsers/Jira/JiraParser.cs
@@ -70,10 +70,10 @@ public class JiraParser : IJiraParser
         var assets = new List<GithubAsset>();
         foreach (var attachment in jiraIssue.Fields.Attachment)
         {
-            var content = githubContent.SingleOrDefault(x => x.Name.Equals(attachment.Filename, StringComparison.OrdinalIgnoreCase));
+            var content = githubContent.SingleOrDefault(x => x.Name.Equals($"{jiraIssue.Key}-{attachment.Filename}", StringComparison.OrdinalIgnoreCase));
             if (!options.Export || content != null)
             {
-                assets.Add(new GithubAsset(content == null ? attachment.Url : content.Url, attachment.Filename));
+                assets.Add(new GithubAsset(content == null ? attachment.Url : content.Url, $"{jiraIssue.Key}-{attachment.Filename}"));
                 continue;
             }
 
@@ -81,7 +81,7 @@ public class JiraParser : IJiraParser
             try
             {
                 var asset = await _githubService
-                    .CreateAttachmentAsync(options.ImportOwner!, options.UploadRepo!, options.ImportPath, fileData, attachment.Filename,
+                    .CreateAttachmentAsync(options.ImportOwner!, options.UploadRepo!, options.ImportPath, fileData, $"{jiraIssue.Key}-{attachment.Filename}",
                         cts)
                     .ConfigureAwait(false);
                 assets.Add(asset);
@@ -132,7 +132,7 @@ public class JiraParser : IJiraParser
             : jiraIssue.Fields.StoryPoints.ToString();
 
         var linkAsContent = options.Link ? string.Empty : "!";
-        var attachments = attachmentsToReplace.Any() ?
+        var attachments = assets.Any() ?
             string.Join(", ", assets.Select(a => $"{linkAsContent}[{a.Name}]({a.Url})")) :
             "N/A";
 
@@ -148,12 +148,13 @@ public class JiraParser : IJiraParser
     private async Task<IEnumerable<GitHubLabel>> GetGithubLabels(JiraIssue jiraIssue, JihubOptions options, List<GitHubLabel> existingLabels, CancellationToken cts)
     {
         var labels = jiraIssue.Fields.Labels
-            .Select(x => new GitHubLabel(x, string.Empty))
+            .Select(x => new GitHubLabel(x, string.Empty, "c5c5c5"))
             .Concat(new GitHubLabel[]
             {
                 new(
                     jiraIssue.Fields.Issuetype.Name,
-                    jiraIssue.Fields.Issuetype.Description
+                    jiraIssue.Fields.Issuetype.Description,
+                    "c5c5c5"
                 )
             });
         var missingLabels = labels

--- a/jihub.Worker/appsettings.json
+++ b/jihub.Worker/appsettings.json
@@ -25,6 +25,8 @@
           "In progress",
           "In Progress",
           "In Review",
+          "Funnel",
+          "Program Backlog",
           "Try"
         ],
         "Closed": [
@@ -33,7 +35,7 @@
         ]
       },
       "EmailMappings": [],
-      "DescriptionTemplate": "{{Description}}\n\n_Components_: {{Components}}\n_Sprints_: {{Sprints}}\n_Fix Versions_: {{FixVersions}}\n_StoryPoints_:{{StoryPoints}}\n_Attachments_:{{Attachments}}"
+      "DescriptionTemplate": "{{Description}}\n\n_Components_: {{Components}}\n_Sprints_: {{Sprints}}\n_Fix Versions_: {{FixVersions}}\n_StoryPoints_: {{StoryPoints}}\n_Attachments_: {{Attachments}}"
     }
   }
 }


### PR DESCRIPTION
# Pull Request

## Description

Attachments are now prefixed with the jira issue id to prevent duplicate naming

## Related Issue

#41 

## Checklist

- [x] I have read and followed the project's [contributing guidelines](https://github.com/Phil91/jihub/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have added necessary documentation or updated the existing documentation.
- [x] My code follows the project's code style and conventions.
- [x] I have reviewed my changes to ensure they do not introduce any potential security vulnerabilities.